### PR TITLE
Consistently sort factors and aws app list

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -71,6 +71,7 @@ class OktaAuth(object):
             if factor['factorType'] == "token:software:totp":
                 supported_factors.append(factor)
 
+        supported_factors = sorted(supported_factors, key=lambda factor: (factor['provider'], factor['factorType']))
         if supported_factors == 1:
             session_token = self.verify_single_factor(supported_factors[0]['id'], state_token)
         elif supported_factors > 0:
@@ -147,6 +148,8 @@ class OktaAuth(object):
         if not aws_apps:
             self.logger.error("No AWS apps are available for your user. Exiting.")
             sys.exit(1)
+
+        aws_apps = sorted(aws_apps, key=lambda app: app['sortOrder'])
         print("Available apps:")
         for index, app in enumerate(aws_apps):
             app_name = app['label']


### PR DESCRIPTION
This PR uses the sortOrder provided from Okta to correctly sort AWS Apps, and utilizes the provider/type to sort the factors list. Currently sort order is not consistent and can change as new AWS apps are added.
