### PR TITLE
Cache credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Flag to output the version.
 - Ability to store AWS Role choice in `~/.okta-aws`. (#4)
 
+### Fixed:
+- Issue #14. Fixed a bug where okta-awscli wasn't connecting to the STS API endpoint in us-gov-west-1 when trying to obtain credential for GovCloud.
+
 ## [0.1.5] 2017-11-15
 ### Fixed:
 - Issue #8. Another pass at trying to fix the MFA list. Factor chosen was being pulled from list which included unsupported factors.

--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ Optional flags:
 - `--force` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
 - `--verbose` More verbose output.
 - `--debug` Very verbose output. Useful for debugging.
+- `--cache` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)
 - `--okta-profile` Use a Okta profile, other than `default` in `.okta-aws`. Useful for multiple Okta tenants.

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -6,8 +6,9 @@ import logging
 from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.aws_auth import AwsAuth
 import click
+import os
 
-def get_credentials(aws_auth, okta_profile, profile, verbose, logger):
+def get_credentials(aws_auth, okta_profile, profile, verbose, logger, cache):
     """ Gets credentials from Okta """
     okta = OktaAuth(okta_profile, verbose, logger)
     app_name, assertion = okta.get_assertion()
@@ -20,7 +21,11 @@ def get_credentials(aws_auth, okta_profile, profile, verbose, logger):
     secret_access_key = token['SecretAccessKey']
     session_token = token['SessionToken']
     if not profile:
-        console_output(access_key_id, secret_access_key, session_token, verbose)
+        exports = console_output(access_key_id, secret_access_key, session_token, verbose)
+        if cache:
+            cache = open("%s/.okta-credentials.cache" % (os.path.expanduser('~'),), 'w')
+            cache.write(exports)
+            cache.close()
         exit(0)
     else:
         aws_auth.write_sts_token(profile, access_key_id, secret_access_key, session_token)
@@ -29,9 +34,14 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
     """ Outputs STS credentials to console """
     if verbose:
         print("Use these to set your environment variables:")
-    print("export AWS_ACCESS_KEY_ID=%s" % access_key_id)
-    print("export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key)
-    print("export AWS_SESSION_TOKEN=%s" % session_token)
+    exports = "\n".join([
+        "export AWS_ACCESS_KEY_ID=%s" % access_key_id,
+        "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
+        "export AWS_SESSION_TOKEN=%s" % session_token
+    ])
+    print(exports)
+
+    return exports
 
 #pylint: disable=R0913
 @click.command()
@@ -45,8 +55,10 @@ If none is provided, then the default profile will be used.")
 @click.option('--profile', help="Name of the profile to store temporary \
 credentials in ~/.aws/credentials. If profile doesn't exist, it will be created. If omitted, credentials \
 will output to console.")
+@click.option('-c', '--cache', is_flag=True, help='Cache the default profile credentials \
+to ~/.okta-credentials.cache')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
-def main(okta_profile, profile, verbose, version, debug, force, awscli_args):
+def main(okta_profile, profile, verbose, version, debug, force, cache, awscli_args):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -72,7 +84,7 @@ def main(okta_profile, profile, verbose, version, debug, force, awscli_args):
             logger.info("Force option selected, getting new credentials anyway.")
         elif force:
             logger.info("Force option selected, but no profile provided. Option has no effect.")
-        get_credentials(aws_auth, okta_profile, profile, verbose, logger)
+        get_credentials(aws_auth, okta_profile, profile, verbose, logger, cache)
 
     if awscli_args:
         cmdline = ['aws', '--profile', profile] + list(awscli_args)


### PR DESCRIPTION
Adding --cache flag to cache acquired credentials to ~/.okta-credentials.cache and closes #7.

This PR helps to address my original workflow issues that led to both issues #6 and #7. Having used this script daily for quite awhile now, I was better able to understand the issues I was having and have come up with a different approach for automating authentication in multiple terminals (without copy/paste).

See https://gist.github.com/justinm/344004899868e86b1e9c9a1d66af02d8 for an example bash script on how this cache can automate the developer authentication workflow, especially when it comes to multiple terminals.