### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
+use-alias-profile = True # Set this to True if you want to use the AWS account alias as the aws profile name. Defaults to False.
+app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
+```
+
+- Initialize the `~/.okta-info.json` file with the following:
+
+```
+{}
 ```
 
 ## Supported Features
@@ -45,11 +53,16 @@ role = <your_preferred_okta_role> # AWS role name (match one of the options prom
 
 `okta-awscli --profile <aws_profile> <awscli action> <awscli arguments>`
 - Follow the prompts to enter MFA information (if required) and choose your AWS app and IAM role.
-- Subsequent executions will first check if the STS credentials are still valid and skip Okta authentication if so.
+- The default Okta profile will not store your chosen IAM role, but other profiles will.
 - Multiple Okta profiles are supported, but if none are specified, then `default` will be used.
 
 
-### Example
+### Examples
+
+`okta-awscli --profile cfer-dev`
+
+This command will simply output STS credentials to `cfer-dev` in your credentials file.
+
 
 `okta-awscli --profile my-aws-account iam list-users`
 
@@ -57,7 +70,8 @@ If no awscli commands are provided, then okta-awscli will simply output STS cred
 
 Optional flags:
 - `--profile` Sets your temporary credentials to a profile in `.aws/credentials`. If omitted, credentials will output to console.
-- `--force` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
+- `--export` Outputs credentials to console instead of writing to ~/.aws/credentials.
+- `--reset` Resets default values in ~/.okta-aws.
 - `--verbose` More verbose output.
 - `--debug` Very verbose output. Useful for debugging.
 - `--cache` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -55,7 +55,7 @@ of roles assigned to you.""" % self.role)
                     print(option)
 
                 role_choice = int(input('Please select the AWS role: ')) - 1
-                return roles[role_choice]
+                return role_info[role_choice]
             except ValueError as ex:
                 print("\nYou have selected an invalid role index, please try again.\n")
                 role_choice = None
@@ -225,7 +225,7 @@ of roles assigned to you.""" % self.role)
     def __create_options_from(roles):
         options = []
         for index, role in enumerate(roles):
-            options.append("[%s]: %s : %s" % (str(index + 1).ljust(2), role[2].ljust(27), role[1]))
+            options.append("[%s]: %s : %s" % (str(index + 1).ljust(2), role[2].ljust(27), role[0]))
         return options
 
     def __find_predefined_role_from(self, roles):

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -1,7 +1,9 @@
 """ AWS authentication """
 # pylint: disable=C0325
 import os
+import json
 import base64
+from datetime import date
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from configparser import RawConfigParser
@@ -29,13 +31,14 @@ class AwsAuth():
             self.role = parser.get(okta_profile, 'role')
             self.logger.debug("Setting AWS role to %s" % self.role)
 
-
     def choose_aws_role(self, assertion):
         """ Choose AWS role from SAML assertion """
 
         roles = self.__extract_available_roles_from(assertion)
+        role_info = self.__get_role_info(roles, assertion)
+
         if self.role:
-            predefined_role = self.__find_predefiend_role_from(roles)
+            predefined_role = self.__find_predefined_role_from(roles)
             if predefined_role:
                 self.logger.info("Using predefined role: %s" % self.role)
                 return predefined_role
@@ -44,12 +47,21 @@ class AwsAuth():
 of roles assigned to you.""" % self.role)
                 self.logger.info("Please choose a role.")
 
-        role_options = self.__create_options_from(roles)
-        for option in role_options:
-            print(option)
+        role_options = self.__create_options_from(role_info)
+        role_choice = None
+        while role_choice is None:
+            try:
+                for option in role_options:
+                    print(option)
 
-        role_choice = int(input('Please select the AWS role: ')) - 1
-        return roles[role_choice]
+                role_choice = int(input('Please select the AWS role: ')) - 1
+                return roles[role_choice]
+            except ValueError as ex:
+                print("\nYou have selected an invalid role index, please try again.\n")
+                role_choice = None
+            except IndexError as ex:
+                print("\nYou have selected an invalid role index, please try again.\n")
+                role_choice = None
 
     @staticmethod
     def get_sts_token(role_arn, principal_arn, assertion):
@@ -99,6 +111,7 @@ of roles assigned to you.""" % self.role)
                 self.logger.info("Temporary credentials have expired. Requesting new credentials.")
                 return False
 
+        print("AWS credentials are still valid.")
         self.logger.info("STS credentials are valid. Nothing to do.")
         return True
 
@@ -124,7 +137,7 @@ of roles assigned to you.""" % self.role)
 
         with open(self.creds_file, 'w+') as configfile:
             config.write(configfile)
-        self.logger.info("Temporary credentials written to profile: %s" % profile)
+        print("Temporary credentials written to profile: %s" % profile)
         self.logger.info("Invoke using: aws --profile %s <service> <command>" % profile)
 
     @staticmethod
@@ -140,14 +153,82 @@ of roles assigned to you.""" % self.role)
                     roles.append(role_tuple(*saml2attributevalue.text.split(',')))
         return roles
 
+    def __get_role_info(self, roles, assertion):
+        """ Gets role info from okta-info.json """
+        info_file_path = os.path.expanduser('~') + "/.okta-info.json"
+        info_file = open(info_file_path, 'r')
+        okta_info = json.loads(info_file.read())
+        info_file.close()
+
+        role_info = []
+        new_okta_info = {}
+        for role in roles:
+            # read the role info from ~/.okta-info.json
+            role_updated = okta_info.get(role, {})
+            alias = role_updated.get('alias')
+
+            last_updated = role_updated.get('last_updated', date.min)
+            current_date = date.today()
+            alias_age = current_date - last_updated
+            if alias_age.days >= 7 or alias is None:
+                self.logger.info("Refreshing cached alias for role %s" % role.role_arn)
+                alias = self.__get_account_alias(role.role_arn, role.principal_arn, assertion)
+                last_updated = current_date
+
+            role_info.append(
+                (role.role_arn, role.principal_arn, alias)
+            )
+            new_okta_info[role.role_arn] = {
+                'last_updated': last_updated,
+                'alias': alias
+            }
+
+        info_file = open(info_file_path, 'w')
+        info_file.write(
+            json.dumps(new_okta_info,
+                sort_keys=True,
+                indent=4,
+                separators=(',', ': '),
+                default=str
+            )
+        )
+        info_file.close()
+        role_info = sorted(role_info, key=lambda role: role[2])
+
+        return role_info
+
+    def __get_account_alias(self, role_arn, principal_arn, assertion):
+        """ Gets  account alias for given role """
+        sts = boto3.client('sts')
+        saml_resp = sts.assume_role_with_saml(
+            RoleArn=role_arn,
+            PrincipalArn=principal_arn,
+            SAMLAssertion=assertion
+        )
+        iam = boto3.client(
+            'iam',
+            aws_access_key_id=saml_resp['Credentials']['AccessKeyId'],
+            aws_secret_access_key=saml_resp['Credentials']['SecretAccessKey'],
+            aws_session_token=saml_resp['Credentials']['SessionToken']
+        )
+
+        try:
+            alias_resp = iam.list_account_aliases()
+            return alias_resp['AccountAliases'][0]
+        except ClientError as ex:
+            if ex.response['Error']['Code'] == 'AccessDenied':
+                self.logger.info(
+                    'Role %s not authorized to perform `list_account_aliases`.' % role_arn)
+            return "unknown"
+
     @staticmethod
     def __create_options_from(roles):
         options = []
         for index, role in enumerate(roles):
-            options.append("%d: %s" % (index + 1, role.role_arn))
+            options.append("[%s]: %s : %s" % (str(index + 1).ljust(2), role[2].ljust(27), role[1]))
         return options
 
-    def __find_predefiend_role_from(self, roles):
+    def __find_predefined_role_from(self, roles):
         found_roles = filter(lambda role_tuple: role_tuple.role_arn == self.role, roles)
         if not found_roles:
             return None

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -3,7 +3,7 @@
 import os
 import json
 import base64
-from datetime import date
+from datetime import datetime, date
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from configparser import RawConfigParser
@@ -129,10 +129,11 @@ of roles assigned to you.""" % self.role)
         new_okta_info = {}
         for role in roles:
             # read the role info from ~/.okta-info.json
-            role_updated = okta_info.get(role, {})
+            role_updated = okta_info.get(role.role_arn, {})
             alias = role_updated.get('alias')
 
-            last_updated = role_updated.get('last_updated', date.min)
+            last_updated = role_updated.get('last_updated', "0001-01-01")
+            last_updated = datetime.strptime(last_updated, '%Y-%m-%d').date()
             current_date = date.today()
             alias_age = current_date - last_updated
             if alias_age.days >= 7 or alias is None:
@@ -140,6 +141,7 @@ of roles assigned to you.""" % self.role)
                 alias = self.__get_account_alias(role.role_arn, role.principal_arn, assertion)
                 last_updated = current_date
 
+            self.logger.info("Using cached alias for role %s" % role.role_arn)
             role_info.append(
                 (role.role_arn, role.principal_arn, alias)
             )

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -11,18 +11,23 @@ try:
 except NameError:
     pass
 
+
 class OktaAuth():
     """ Handles auth to Okta and returns SAML assertion """
-    def __init__(self, okta_profile, verbose, logger, totp_token, okta_auth_config):
+    def __init__(self, okta_profile, verbose, logger,
+                 totp_token, okta_auth_config):
         self.okta_profile = okta_profile
         self.totp_token = totp_token
         self.logger = logger
         self.factor = ""
         self.verbose = verbose
+        self.okta_auth_config = okta_auth_config
         self.https_base_url = "https://%s" % okta_auth_config.base_url_for(okta_profile)
         self.username = okta_auth_config.username_for(okta_profile)
         self.password = okta_auth_config.password_for(okta_profile)
         self.factor = okta_auth_config.factor_for(okta_profile)
+        self.app = okta_auth_config.app_for(okta_profile)
+
 
     def primary_auth(self):
         """ Performs primary auth against Okta """
@@ -58,8 +63,7 @@ class OktaAuth():
             if factor['factorType'] in supported_factor_types:
                 supported_factors.append(factor)
             else:
-                self.logger.info("Unsupported factorType: %s" %
-                                 (factor['factorType'],))
+                self.logger.info("Unsupported factorType: %s" % (factor['factorType'],))
 
         supported_factors = sorted(supported_factors,
                                    key=lambda factor: (
@@ -94,7 +98,8 @@ class OktaAuth():
                 else:
                     print("%d: %s" % (index + 1, factor_name))
             if not self.factor:
-                factor_choice = input('Please select the MFA factor: ') - 1
+                factor_choice = int(input('Please select the MFA factor: ')) - 1
+                self.okta_auth_config.save_chosen_factor_for_profile(self.okta_profile, supported_factors[factor_choice]['provider'])
             self.logger.info("Performing secondary authentication using: %s" %
                              supported_factors[factor_choice]['provider'])
             session_token = self.verify_single_factor(supported_factors[factor_choice],
@@ -172,12 +177,15 @@ class OktaAuth():
             sys.exit(1)
 
         aws_apps = sorted(aws_apps, key=lambda app: app['sortOrder'])
-        print("Available apps:")
+        app_choice = None
         for index, app in enumerate(aws_apps):
-            app_name = app['label']
-            print("%d: %s" % (index + 1, app_name))
+            if self.app and app['label'] == self.app:
+                app_choice = index
+                break
+            print("%d: %s" % (index + 1, app['label']))
+        if app_choice is None:
+            app_choice = int(input('Please select AWS app: ')) - 1
 
-        app_choice = int(input('Please select AWS app: ')) - 1
         return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
 
     def get_saml_assertion(self, html):

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -185,6 +185,10 @@ class OktaAuth():
             print("%d: %s" % (index + 1, app['label']))
         if app_choice is None:
             app_choice = int(input('Please select AWS app: ')) - 1
+            self.okta_auth_config.save_chosen_app_for_profile(
+                self.okta_profile,
+                aws_apps[app_choice]['label']
+            )
 
         return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
 

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -63,8 +63,18 @@ class OktaAuthConfig():
             return app
         return None
 
+    def get_profile_alias(self, okta_profile):
+        """ Gets if should use alias as profile from config """
+        use_alias_as_profile = "False"
+        if self._value.has_option(okta_profile, 'use-alias-profile'):
+            use_alias_as_profile = self._value.get(okta_profile, 'use-alias-profile')
+        else:
+            use_alias_as_profile = self._value.get('default', 'use-alias-profile')
+        self.logger.info("Use alias as profile: %s" % use_alias_as_profile)
+        return use_alias_as_profile
+
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
-        """ Gets role from config """
+        """ Saves role to config """
         if not self._value.has_section(okta_profile):
             self._value.add_section(okta_profile)
 

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -10,6 +10,7 @@ try:
 except NameError:
     pass
 
+
 class OktaAuthConfig():
     """ Config helper class """
     def __init__(self, logger):
@@ -53,6 +54,14 @@ class OktaAuthConfig():
             return factor
         return None
 
+    def app_for(self, okta_profile):
+        """ Gets app from config """
+        if self._value.has_option(okta_profile, 'app'):
+            app = self._value.get(okta_profile, 'app')
+            self.logger.debug("Setting app to %s" % app)
+            return app
+        return None
+
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
         """ Gets role from config """
         if not self._value.has_section(okta_profile):
@@ -60,7 +69,18 @@ class OktaAuthConfig():
 
         base_url = self.base_url_for(okta_profile)
         self._value.set(okta_profile, 'base-url', base_url)
-        self._value.set(okta_profile, 'role', role_arn)
+        if okta_profile != "default":
+            self._value.set(okta_profile, 'role', role_arn)
+
+        with open(self.config_path, 'w+') as configfile:
+            self._value.write(configfile)
+
+    def save_chosen_factor_for_profile(self, okta_profile, factor):
+        """ Saves factor to config """
+        if not self._value.has_section(okta_profile):
+            self._value.add_section(okta_profile)
+
+        self._value.set(okta_profile, 'factor', factor)
 
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -13,8 +13,9 @@ except NameError:
 
 class OktaAuthConfig():
     """ Config helper class """
-    def __init__(self, logger):
+    def __init__(self, logger, reset):
         self.logger = logger
+        self.reset = reset
         self.config_path = os.path.expanduser('~') + '/.okta-aws'
         self._value = RawConfigParser()
         self._value.read(self.config_path)
@@ -31,7 +32,7 @@ class OktaAuthConfig():
 
     def username_for(self, okta_profile):
         """ Gets username from config """
-        if self._value.has_option(okta_profile, 'username'):
+        if self._value.has_option(okta_profile, 'username') and not self.reset:
             username = self._value.get(okta_profile, 'username')
             self.logger.info("Authenticating as: %s" % username)
         else:
@@ -48,7 +49,7 @@ class OktaAuthConfig():
 
     def factor_for(self, okta_profile):
         """ Gets factor from config """
-        if self._value.has_option(okta_profile, 'factor'):
+        if self._value.has_option(okta_profile, 'factor') and not self.reset:
             factor = self._value.get(okta_profile, 'factor')
             self.logger.debug("Setting MFA factor to %s" % factor)
             return factor
@@ -56,7 +57,7 @@ class OktaAuthConfig():
 
     def app_for(self, okta_profile):
         """ Gets app from config """
-        if self._value.has_option(okta_profile, 'app'):
+        if self._value.has_option(okta_profile, 'app') and not self.reset:
             app = self._value.get(okta_profile, 'app')
             self.logger.debug("Setting app to %s" % app)
             return app
@@ -81,6 +82,16 @@ class OktaAuthConfig():
             self._value.add_section(okta_profile)
 
         self._value.set(okta_profile, 'factor', factor)
+
+        with open(self.config_path, 'w+') as configfile:
+            self._value.write(configfile)
+
+    def save_chosen_app_for_profile(self, okta_profile, app):
+        """ Saves app to config """
+        if not self._value.has_section(okta_profile):
+            self._value.add_section(okta_profile)
+
+        self._value.set(okta_profile, 'app', app)
 
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -68,8 +68,7 @@ class OktaAuthConfig():
         use_alias_as_profile = "False"
         if self._value.has_option(okta_profile, 'use-alias-profile'):
             use_alias_as_profile = self._value.get(okta_profile, 'use-alias-profile')
-        else:
-            use_alias_as_profile = self._value.get('default', 'use-alias-profile')
+
         self.logger.info("Use alias as profile: %s" % use_alias_as_profile)
         return use_alias_as_profile
 

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -15,13 +15,15 @@ def get_credentials(aws_auth, okta_profile, profile,
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
     use_alias = okta_auth_config.get_profile_alias(okta_profile)
+    print(use_alias)
+    print(type(use_alias))
 
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
     role_arn, principal_arn, alias = role
-    if use_alias:
+    if use_alias == "True":
         profile = alias
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -15,9 +15,6 @@ def get_credentials(aws_auth, okta_profile, profile,
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
     use_alias = okta_auth_config.get_profile_alias(okta_profile)
-    print(use_alias)
-    print(type(use_alias))
-
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
@@ -70,7 +67,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
 @click.option('-r', '--reset', is_flag=True, help='Resets default values in ~/.okta-aws')
 @click.option('-e', '--export', is_flag=True, help='Outputs credentials to console instead \
-of writing to ~/.aws/credentials.')
+of writing to ~/.aws/credentials')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
 If none is provided, then the default profile will be used.\n")
 @click.option('--profile', help="Name of the profile to store temporary \

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -65,8 +65,6 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
               help='Outputs version number and exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
 @click.option('-r', '--reset', is_flag=True, help='Resets default values in ~/.okta-aws')
-@click.option('-f', '--force', is_flag=True, help='Forces new STS credentials. \
-Skips STS credentials validation.')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
 If none is provided, then the default profile will be used.\n")
 @click.option('--profile', help="Name of the profile to store temporary \
@@ -77,7 +75,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
-         debug, force, cache, awscli_args, token, reset):
+         debug, cache, awscli_args, token, reset):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -100,12 +98,7 @@ def main(okta_profile, profile, verbose, version,
     if not profile:
         profile = "default"
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger, reset)
-    if force and profile:
-        logger.info("Force option selected, \
-            getting new credentials anyway.")
-    elif force:
-        logger.info("Force option selected, but no profile provided. \
-            Option has no effect.")
+    logger.info("Getting new credentials.")
     get_credentials(
         aws_auth, okta_profile, profile, verbose, logger, token, cache, reset
     )

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,14 +11,16 @@ from oktaawscli.aws_auth import AwsAuth
 
 
 def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, logger, totp_token, cache):
+                    verbose, logger, totp_token, cache, reset):
     """ Gets credentials from Okta """
-    okta_auth_config = OktaAuthConfig(logger)
+    okta_auth_config = OktaAuthConfig(logger, reset)
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
-    principal_arn, role_arn = role
+    print(role)
+    role_arn, principal_arn, _= role
+    print(role_arn)
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
 
@@ -60,6 +62,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 @click.option('-V', '--version', is_flag=True,
               help='Outputs version number and exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
+@click.option('-r', '--reset', is_flag=True, help='Resets default values in ~/.okta-aws')
 @click.option('-f', '--force', is_flag=True, help='Forces new STS credentials. \
 Skips STS credentials validation.')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
@@ -72,7 +75,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
-         debug, force, cache, awscli_args, token):
+         debug, force, cache, awscli_args, token, reset):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -103,7 +106,7 @@ def main(okta_profile, profile, verbose, version,
             logger.info("Force option selected, but no profile provided. \
                 Option has no effect.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, reset
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -9,10 +9,10 @@ from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
+
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache):
     """ Gets credentials from Okta """
-
     okta_auth_config = OktaAuthConfig(logger)
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
@@ -66,7 +66,7 @@ Skips STS credentials validation.')
 If none is provided, then the default profile will be used.\n")
 @click.option('--profile', help="Name of the profile to store temporary \
 credentials in ~/.aws/credentials. If profile doesn't exist, it will be \
-created. If omitted, credentials will output to console.\n")
+created.\n")
 @click.option('-c', '--cache', is_flag=True, help='Cache the default profile credentials \
 to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
@@ -92,6 +92,8 @@ def main(okta_profile, profile, verbose, version,
 
     if not okta_profile:
         okta_profile = "default"
+    if not profile:
+        profile = "default"
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger)
     if not aws_auth.check_sts_token(profile) or force:
         if force and profile:

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.2.3'
+__version__ = '0.3.0'


### PR DESCRIPTION
* select app specified by `app` field in config if `app` field exists
* only store role for non default profiles
* graciously reprompt for role index on bad selection
* require a `~/.okta-info.json` file to store account aliases
* fetch account aliases to display in list of roles
* cache account aliases in `~/.okta-info.json` along with time last updated
* refresh account alias if last updated over a week ago
* write aws creds to `default` profile if no `--profile` specified
* add `use-alias-profile` field to config to write to aws profile named for chosen account alias  
* remove force flag 
* removing check to make sure creds are invalid before refreshing
* add export flag to print creds to console
* add reset flag to reset fields in `~/.okta-aws` 
* remember factor for default okta profiles, prompt for non-default profiles
* non-default okta profiles remember factor after first prompt