### PR TITLE
Fix casting error on selection

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -94,7 +94,7 @@ class OktaAuth():
                 else:
                     print("%d: %s" % (index + 1, factor_name))
             if not self.factor:
-                factor_choice = input('Please select the MFA factor: ') - 1
+                factor_choice = int(input('Please select the MFA factor: ')) - 1
             self.logger.info("Performing secondary authentication using: %s" %
                              supported_factors[factor_choice]['provider'])
             session_token = self.verify_single_factor(supported_factors[factor_choice],


### PR DESCRIPTION
Was getting error:

  File "/Library/Python/2.7/site-packages/oktaawscli/okta_auth.py", line 97, in verify_mfa
    factor_choice = input('Please select the MFA factor: ') - 1
TypeError: unsupported operand type(s) for -: 'str' and 'int'