### PR TITLE
Use as list instead of assuming iterable

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -152,4 +152,4 @@ of roles assigned to you.""" % self.role)
         if not found_roles:
             return None
         else:
-            return next(found_roles)
+            return found_roles[0]


### PR DESCRIPTION
Was seeing this error:

  File "/Library/Python/2.7/site-packages/oktaawscli/aws_auth.py", line 155, in __find_predefiend_role_from
    return next(found_roles)
TypeError: list object is not an iterator