### PR TITLE
to fix "TypeError: list object is not an iterator"

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -152,4 +152,7 @@ of roles assigned to you.""" % self.role)
         if not found_roles:
             return None
         else:
-            return next(found_roles)
+            try:
+                return next(found_roles)
+            except: 
+                return None


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/bin/okta-awscli", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/oktaawscli/okta_awscli.py", line 104, in main
    aws_auth, okta_profile, profile, verbose, logger, token, cache
  File "/usr/local/lib/python2.7/site-packages/oktaawscli/okta_awscli.py", line 20, in get_credentials
    role = aws_auth.choose_aws_role(assertion)
  File "/usr/local/lib/python2.7/site-packages/oktaawscli/aws_auth.py", line 38, in choose_aws_role
    predefined_role = self.__find_predefiend_role_from(roles)
  File "/usr/local/lib/python2.7/site-packages/oktaawscli/aws_auth.py", line 155, in __find_predefiend_role_from
    return next(found_roles)
TypeError: list object is not an iterator