### PR TITLE
Add ability to store the AWS App choice to `~/.okta-aws`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.5] 2018-10-18
+### Added:
+- Ability to store AWS App choice in `~/.okta-aws`.
+
 ## [0.2.4] 2018-09-03
 ### Fixed:
 - Casting issue with MFA factor selection. (#44)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
+app-link = <app_link_from_okta> # Found in Okta's configuration for your AWS account.
 ```
 
 ## Supported Features
@@ -47,7 +48,7 @@ role = <your_preferred_okta_role> # AWS role name (match one of the options prom
 - Follow the prompts to enter MFA information (if required) and choose your AWS app and IAM role.
 - Subsequent executions will first check if the STS credentials are still valid and skip Okta authentication if so.
 - Multiple Okta profiles are supported, but if none are specified, then `default` will be used.
-
+- Selections for AWS App and AWS Role are saved to the `~/.okta-aws` file. Removing the `app-link` and `role` fields will enable the prompts for these selections.
 
 ### Example
 

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -152,4 +152,4 @@ of roles assigned to you.""" % self.role)
         if not found_roles:
             return None
         else:
-            return next(found_roles)
+            return next(iter(found_roles))

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -23,6 +23,8 @@ class OktaAuth():
         self.username = okta_auth_config.username_for(okta_profile)
         self.password = okta_auth_config.password_for(okta_profile)
         self.factor = okta_auth_config.factor_for(okta_profile)
+        self.app_link = okta_auth_config.app_link_for(okta_profile)
+        self.okta_auth_config = okta_auth_config
 
     def primary_auth(self):
         """ Performs primary auth against Okta """
@@ -198,7 +200,12 @@ class OktaAuth():
         """ Main method to get SAML assertion from Okta """
         session_token = self.primary_auth()
         session_id = self.get_session(session_token)
-        app_name, app_link = self.get_apps(session_id)
+        if not self.app_link:
+            app_name, app_link = self.get_apps(session_id)
+            self.okta_auth_config.save_chosen_app_link_for_profile(self.okta_profile, app_link)
+        else:
+            app_name = None
+            app_link = self.app_link
         sid = "sid=%s" % session_id
         headers = {'Cookie': sid}
         resp = requests.get(app_link, headers=headers)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -28,6 +28,16 @@ class OktaAuthConfig():
             self.logger.info("Using base-url from default profile %s" % base_url)
         return base_url
 
+    def app_link_for(self, okta_profile):
+        """ Gets app_link from config """
+        app_link = None
+        if self._value.has_option(okta_profile, 'app-link'):
+            app_link = self._value.get(okta_profile, 'app-link')
+        elif self._value.has_option('default', 'app-link'):
+            app_link = self._value.get('default', 'app-link')
+        self.logger.info("App Link set as: %s" % app_link)
+        return app_link
+
     def username_for(self, okta_profile):
         """ Gets username from config """
         if self._value.has_option(okta_profile, 'username'):
@@ -61,6 +71,18 @@ class OktaAuthConfig():
         base_url = self.base_url_for(okta_profile)
         self._value.set(okta_profile, 'base-url', base_url)
         self._value.set(okta_profile, 'role', role_arn)
+
+        with open(self.config_path, 'w+') as configfile:
+            self._value.write(configfile)
+
+    def save_chosen_app_link_for_profile(self, okta_profile, app_link):
+        """ Gets role from config """
+        if not self._value.has_section(okta_profile):
+            self._value.add_section(okta_profile)
+
+        base_url = self.base_url_for(okta_profile)
+        self._value.set(okta_profile, 'base-url', base_url)
+        self._value.set(okta_profile, 'app-link', app_link)
 
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.2.4'
+__version__ = '0.2.5'


### PR DESCRIPTION
Having the ability to save the AWS App information allows for scripted use of this tool as the app no longer prompts for user input when `app-link` is added to the appropriate profile(s) in the configuration file.  This PR also provides an alternative fix for the issues around the exceptions when returning a filtered role.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmhale/okta-awscli/54)
<!-- Reviewable:end -->
