### PR TITLE
support setting custom duration on default account, solves #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.0] 2018-12-10
+### Added:
+- Ability to set requested token duration. (#43).
+
 ## [0.2.5] 2018-10-18
 ### Added:
 - Ability to store AWS App choice in `~/.okta-aws`. (#12)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ password = <your_okta_password> # Only save your password if you know what you a
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 app-link = <app_link_from_okta> # Found in Okta's configuration for your AWS account.
-duration = 3600 # duration in seconds to request a session token for, make sure your account allows for large durations. default: 3600
+duration = 3600 # duration in seconds to request a session token for, make sure your accounts (both AWS itself and the associated okta application) allow for large durations. default: 3600
 ```
 
 ## Supported Features

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ password = <your_okta_password> # Only save your password if you know what you a
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 app-link = <app_link_from_okta> # Found in Okta's configuration for your AWS account.
+duration = 3600 # duration in seconds to request a session token for, make sure your account allows for large durations. default: 3600
 ```
 
 ## Supported Features

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -25,7 +25,9 @@ class OktaAuthConfig():
             self.logger.info("Authenticating to: %s" % base_url)
         else:
             base_url = self._value.get('default', 'base-url')
-            self.logger.info("Using base-url from default profile %s" % base_url)
+            self.logger.info(
+                "Using base-url from default profile %s" % base_url
+            )
         return base_url
 
     def app_link_for(self, okta_profile):
@@ -61,6 +63,22 @@ class OktaAuthConfig():
             factor = self._value.get(okta_profile, 'factor')
             self.logger.debug("Setting MFA factor to %s" % factor)
             return factor
+        return None
+
+    def duration_for(self, okta_profile):
+        """ Gets requested duration from config, ignore it on failure """
+        if self._value.has_option(okta_profile, 'duration'):
+            duration = self._value.get(okta_profile, 'duration')
+            self.logger.debug(
+                "Requesting a duration of %s seconds" % duration
+            )
+            try:
+                return int(duration)
+            except ValueError as e:
+                self.logger.warn(
+                    "Duration could not be converted to a number,"
+                    " ignoring."
+                )
         return None
 
     def save_chosen_role_for_profile(self, okta_profile, role_arn):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -21,11 +21,20 @@ def get_credentials(aws_auth, okta_profile, profile,
     principal_arn, role_arn = role
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
+    duration = okta_auth_config.duration_for(okta_profile)
 
-    sts_token = aws_auth.get_sts_token(role_arn, principal_arn, assertion)
+    sts_token = aws_auth.get_sts_token(
+        role_arn,
+        principal_arn,
+        assertion,
+        duration=duration,
+        logger=logger
+    )
     access_key_id = sts_token['AccessKeyId']
     secret_access_key = sts_token['SecretAccessKey']
     session_token = sts_token['SessionToken']
+    session_token_expiry = sts_token['Expiration']
+    logger.info("Session token expires on: %s" % session_token_expiry)
     if not profile:
         exports = console_output(access_key_id, secret_access_key,
                                  session_token, verbose)

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.2.5'
+__version__ = '0.3.0'


### PR DESCRIPTION
So this PR sets a custom duration if defined in the configuration, I'll admit the code is a bit awkward in places (namely passing logger to the static `get_sts_token`), I've not been able to test this with multiple accounts, but it does "workforme" quite thoroughly.

setting too high a duration (in general) and a too high duration for a role gracefully dump an error and exit with `-1`, invalid integer for duration is ignored with a message (and implicitly defaults to 3600)

Happy to re-visit anything that doesn't fit in to the project.

and on that note: thank you for putting `okta-awscli` together, it's so much more efficient/better than the oktadeveloper stuff

**note**: this does *not* optimistically check that a duration is valid for the role