### PR TITLE
Add support for per-app MFA

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -1,5 +1,6 @@
 """ Handles auth to Okta and returns SAML assertion """
 # pylint: disable=C0325,R0912,C1801
+# Incorporates flow auth code taken from https://github.com/Nike-Inc/gimme-aws-creds
 import sys
 import time
 import requests

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -3,6 +3,8 @@
 import sys
 import time
 import requests
+import re
+from codecs import decode
 
 from bs4 import BeautifulSoup as bs
 
@@ -26,12 +28,18 @@ class OktaAuth():
         self.logger = logger
         self.factor = ""
         self.verbose = verbose
+        self._verify_ssl_certs = True
+        self._preferred_mfa_type = None
+        self._mfa_code = None
         self.https_base_url = "https://%s" % okta_auth_config.base_url_for(okta_profile)
         self.username = okta_auth_config.username_for(okta_profile)
         self.password = okta_auth_config.password_for(okta_profile)
         self.factor = okta_auth_config.factor_for(okta_profile)
         self.app_link = okta_auth_config.app_link_for(okta_profile)
         self.okta_auth_config = okta_auth_config
+        self.session = None
+        self.session_token = ""
+        self.session_id = ""
 
     def primary_auth(self):
         """ Performs primary auth against Okta """
@@ -40,8 +48,10 @@ class OktaAuth():
             "username": self.username,
             "password": self.password
         }
-        resp = requests.post(self.https_base_url + '/api/v1/authn', json=auth_data)
+        self.session = requests.Session()
+        resp = self.session.post(self.https_base_url + '/api/v1/authn', json=auth_data)
         resp_json = resp.json()
+        self.cookies = resp.cookies
         if 'status' in resp_json:
             if resp_json['status'] == 'MFA_REQUIRED':
                 factors_list = resp_json['_embedded']['factors']
@@ -51,7 +61,7 @@ class OktaAuth():
                 session_token = resp_json['sessionToken']
             elif resp_json['status'] == 'MFA_ENROLL':
                 self.logger.warning("""MFA not enrolled. Cannot continue.
-Please enroll a MFA factor in the Okta Web UI first!""")
+Please enroll an MFA factor in the Okta Web UI first!""")
                 exit(2)
         elif resp.status_code != 200:
             self.logger.error(resp_json['errorSummary'])
@@ -59,6 +69,7 @@ Please enroll a MFA factor in the Okta Web UI first!""")
         else:
             self.logger.error(resp_json)
             exit(1)
+
 
         return session_token
 
@@ -74,7 +85,7 @@ Please enroll a MFA factor in the Okta Web UI first!""")
             if factor['factorType'] in supported_factor_types:
                 supported_factors.append(factor)
             else:
-                self.logger.info("Unsupported factorType: %s" %
+                self.logger.error("Unsupported factorType: %s" %
                                  (factor['factorType'],))
 
         supported_factors = sorted(supported_factors,
@@ -205,7 +216,7 @@ Please enroll a MFA factor in the Okta Web UI first!""")
     def get_session(self, session_token):
         """ Gets a session cookie from a session token """
         data = {"sessionToken": session_token}
-        resp = requests.post(
+        resp = self.session.post(
             self.https_base_url + '/api/v1/sessions', json=data).json()
         return resp['id']
 
@@ -213,7 +224,7 @@ Please enroll a MFA factor in the Okta Web UI first!""")
         """ Gets apps for the user """
         sid = "sid=%s" % session_id
         headers = {'Cookie': sid}
-        resp = requests.get(
+        resp = self.session.get(
             self.https_base_url + '/api/v1/users/me/appLinks',
             headers=headers).json()
         aws_apps = []
@@ -237,32 +248,300 @@ Please enroll a MFA factor in the Okta Web UI first!""")
         self.logger.debug("Selected app: %s" % aws_apps[app_choice]['label'])
         return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
 
-    def get_saml_assertion(self, html):
-        """ Returns the SAML assertion from HTML """
+    def get_simple_assertion(self, html):
         soup = bs(html.text, "html.parser")
-        assertion = ''
-
         for input_tag in soup.find_all('input'):
             if input_tag.get('name') == 'SAMLResponse':
-                assertion = input_tag.get('value')
+                return input_tag.get('value')
+
+        return None
+
+    def get_mfa_assertion(self, html):
+        soup = bs(html.text, "html.parser")
+        if hasattr(soup.title, 'string') and re.match(".* - Extra Verification$", soup.title.string):
+            state_token = decode(re.search(r"var stateToken = '(.*)';", html.text).group(1), "unicode-escape")
+        else:
+            self.logger.error("No Extra Verification")
+            return None
+
+        self.session.cookies['oktaStateToken'] = state_token
+        self.session.cookies['mp_Account Settings__c'] = '0'
+        self.session.cookies['Okta_Verify_Autopush_2012557501'] = 'true'
+        self.session.cookies['Okta_Verify_Autopush_-610254449'] = 'true'
+
+        api_response = self.stepup_auth(self.https_base_url + '/api/v1/authn', state_token)
+        resp = self.session.get(self.app_link)
+
+        return self.get_saml_assertion(resp)
+
+    def get_saml_assertion(self, html):
+        """ Returns the SAML assertion from HTML """
+        assertion = self.get_simple_assertion(html) or self.get_mfa_assertion(html)
 
         if not assertion:
             self.logger.error("SAML assertion not valid: " + assertion)
             exit(-1)
         return assertion
 
+    def stepup_auth(self, embed_link, state_token=None):
+        """ Login to Okta using the Step-up authentication flow"""
+        flow_state = self._get_initial_flow_state(embed_link, state_token)
+
+        while flow_state.get('apiResponse').get('status') != 'SUCCESS':
+            flow_state = self._next_login_step(
+                flow_state.get('stateToken'), flow_state.get('apiResponse'))
+
+        return flow_state['apiResponse']
+
+    def _next_login_step(self, state_token, login_data):
+        """ decide what the next step in the login process is"""
+        if 'errorCode' in login_data:
+            self.logger.error("LOGIN ERROR: {} | Error Code: {}".format(login_data['errorSummary'], login_data['errorCode']))
+            exit(2)
+
+        status = login_data['status']
+
+        if status == 'UNAUTHENTICATED':
+            return self._login_username_password(state_token, login_data['_links']['next']['href'])
+        elif status == 'LOCKED_OUT':
+            self.logger.error("Your Okta access has been locked out due to failed login attempts.")
+            exit(2)
+        elif status == 'MFA_ENROLL':
+            self.logger.error("You must enroll in MFA before using this tool.")
+            exit(2)
+        elif status == 'MFA_REQUIRED':
+            return self._login_multi_factor(state_token, login_data)
+        elif status == 'MFA_CHALLENGE':
+            if 'factorResult' in login_data and login_data['factorResult'] == 'WAITING':
+                return self._check_push_result(state_token, login_data)
+            else:
+                return self._login_input_mfa_challenge(state_token, login_data['_links']['next']['href'])
+        else:
+            raise RuntimeError('Unknown login status: ' + status)
+
+
+    def _get_initial_flow_state(self, embed_link, state_token=None):
+        """ Starts the authentication flow with Okta"""
+        if state_token is None:
+            response = self.session.get(
+                embed_link, allow_redirects=False)
+            url_parse_results = urlparse(response.headers['Location'])
+            state_token = parse_qs(url_parse_results.query)['stateToken'][0]
+
+        response = self.session.post(
+            self.https_base_url + '/api/v1/authn',
+            json={'stateToken': state_token},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        return {'stateToken': state_token, 'apiResponse': response.json()}
+
+    def _get_headers(self):
+        return {
+            'User-Agent': 'Okta-awscli/0.0.1',
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+
     def get_assertion(self):
         """ Main method to get SAML assertion from Okta """
-        session_token = self.primary_auth()
-        session_id = self.get_session(session_token)
+        self.session_token = self.primary_auth()
+        self.session_id = self.get_session(self.session_token)
         if not self.app_link:
             app_name, app_link = self.get_apps(session_id)
             self.okta_auth_config.save_chosen_app_link_for_profile(self.okta_profile, app_link)
         else:
             app_name = None
             app_link = self.app_link
-        sid = "sid=%s" % session_id
-        headers = {'Cookie': sid}
-        resp = requests.get(app_link, headers=headers)
+        self.session.cookies['sid'] = self.session_id
+        resp = self.session.get(app_link)
         assertion = self.get_saml_assertion(resp)
         return app_name, assertion
+
+    def _login_username_password(self, state_token, url):
+        """ login to Okta with a username and password"""
+        creds = self._get_username_password_creds()
+
+        login_json = {
+            'username': creds['username'],
+            'password': creds['password']
+        }
+
+        # If this isn't a Step-up auth flow, we won't have a stateToken
+        if state_token is not None:
+            login_json['stateToken'] = state_token
+
+        response = self.session.post(
+            url,
+            json=login_json,
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        response_data = response.json()
+        if 'errorCode' in response_data:
+            self.logger.error("LOGIN ERROR: {} | Error Code: {}".format(response_data['errorSummary'], response_data['errorCode']))
+
+            if self.KEYRING_ENABLED:
+                try:
+                    keyring.delete_password(self.KEYRING_SERVICE, creds['username'])
+                except PasswordDeleteError:
+                    pass
+
+            exit(2)
+
+        func_result = {'apiResponse': response_data}
+        if 'stateToken' in response_data:
+            func_result['stateToken'] = response_data['stateToken']
+
+        return func_result
+
+    def _login_send_sms(self, state_token, factor):
+        """ Send SMS message for second factor authentication"""
+        response = self.session.post(
+            factor['_links']['verify']['href'],
+            json={'stateToken': state_token},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        self.logger.info("A verification code has been sent to " + factor['profile']['phoneNumber'])
+        response_data = response.json()
+
+        if 'stateToken' in response_data:
+            return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+        if 'sessionToken' in response_data:
+            return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
+
+    def _login_send_call(self, state_token, factor):
+        """ Send Voice call for second factor authentication"""
+        response = self.session.post(
+            factor['_links']['verify']['href'],
+            json={'stateToken': state_token},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        self.logger.info("You should soon receive a phone call at " + factor['profile']['phoneNumber'])
+        response_data = response.json()
+
+        if 'stateToken' in response_data:
+            return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+        if 'sessionToken' in response_data:
+            return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
+
+
+    def _login_send_push(self, state_token, factor):
+        """ Send 'push' for the Okta Verify mobile app """
+        response = self.session.post(
+            factor['_links']['verify']['href'],
+            json={'stateToken': state_token},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        self.logger.info("Okta Verify push sent...")
+        response_data = response.json()
+
+        if 'stateToken' in response_data:
+            return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+        if 'sessionToken' in response_data:
+            return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
+
+    def _login_multi_factor(self, state_token, login_data):
+        """ handle multi-factor authentication with Okta"""
+        factor = self._choose_factor(login_data['_embedded']['factors'])
+        if factor['factorType'] == 'sms':
+            return self._login_send_sms(state_token, factor)
+        elif factor['factorType'] == 'call':
+            return self._login_send_call(state_token, factor)
+        elif factor['factorType'] == 'token:software:totp':
+            return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
+        elif factor['factorType'] == 'token':
+            return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
+        elif factor['factorType'] == 'push':
+            return self._login_send_push(state_token, factor)
+
+    def _login_input_mfa_challenge(self, state_token, next_url):
+        """ Submit verification code for SMS or TOTP authentication methods"""
+        pass_code = self._mfa_code;
+        if pass_code is None:
+            pass_code = input("Enter verification code: ")
+        response = self.session.post(
+            next_url,
+            json={'stateToken': state_token, 'passCode': pass_code},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        response_data = response.json()
+        if 'status' in response_data and response_data['status'] == 'SUCCESS':
+            if 'stateToken' in response_data:
+                return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+            if 'sessionToken' in response_data:
+                return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
+        else:
+            return {'stateToken': None, 'sessionToken': None, 'apiResponse': response_data}
+
+    def _check_push_result(self, state_token, login_data):
+        """ Check Okta API to see if the push request has been responded to"""
+        time.sleep(1)
+        response = self.session.post(
+            login_data['_links']['next']['href'],
+            json={'stateToken': state_token},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+
+        response_data = response.json()
+        if 'stateToken' in response_data:
+            return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+        if 'sessionToken' in response_data:
+            return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
+
+    def _choose_factor(self, factors):
+        """ gets a list of available authentication factors and
+        asks the user to select the factor they want to use """
+
+        print("Multi-factor Authentication required.")
+
+        # filter the factor list down to just the types specified in preferred_mfa_type
+        if self._preferred_mfa_type is not None:
+            factors = list(filter(lambda item: item['factorType'] == self._preferred_mfa_type, factors))
+
+        if len(factors) == 1:
+            factor_name = self._build_factor_name(factors[0])
+            self.logger.info(factor_name, 'selected')
+            selection = 0
+        else:
+            print("Pick a factor:")
+            # print out the factors and let the user select
+            for i, factor in enumerate(factors):
+                factor_name = self._build_factor_name(factor)
+                if factor_name is not "":
+                    print('[ %d ] %s' % (i, factor_name))
+            selection = input("Selection: ")
+
+        # make sure the choice is valid
+        if int(selection) > len(factors):
+            self.logger.error("You made an invalid selection")
+            exit(1)
+
+        return factors[int(selection)]
+
+    @staticmethod
+    def _build_factor_name(factor):
+        """ Build the display name for a MFA factor based on the factor type"""
+        if factor['factorType'] == 'push':
+            return "Okta Verify App: " + factor['profile']['deviceType'] + ": " + factor['profile']['name']
+        elif factor['factorType'] == 'sms':
+            return factor['factorType'] + ": " + factor['profile']['phoneNumber']
+        elif factor['factorType'] == 'call':
+            return factor['factorType'] + ": " + factor['profile']['phoneNumber']
+        elif factor['factorType'] == 'token:software:totp':
+            return factor['factorType'] + "( " + factor['provider'] + " ) : " + factor['profile']['credentialId']
+        elif factor['factorType'] == 'token':
+            return factor['factorType'] + ": " + factor['profile']['credentialId']
+        else:
+            return ("Unknown MFA type: " + factor['factorType'])

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.3.1'
+__version__ = '0.3.1-nonspecialist'

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.3.1-nonspecialist'
+__version__ = '0.3.2'


### PR DESCRIPTION
This PR attempts to address #36 by including relevant code from https://github.com/Nike-Inc/gimme-aws-creds/blob/master/gimme_aws_creds/okta.py

I've validated the `push` and `TOTP` flows, but don't have the ability to enrol any other auth factor to test.