### PR TITLE
Update self.app_link when saving to profile - to fix MFA handling

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -353,13 +353,12 @@ Please enroll an MFA factor in the Okta Web UI first!""")
         self.session_token = self.primary_auth()
         self.session_id = self.get_session(self.session_token)
         if not self.app_link:
-            app_name, app_link = self.get_apps(self.session_id)
-            self.okta_auth_config.save_chosen_app_link_for_profile(self.okta_profile, app_link)
+            app_name, self.app_link = self.get_apps(self.session_id)
+            self.okta_auth_config.save_chosen_app_link_for_profile(self.okta_profile, self.app_link)
         else:
             app_name = None
-            app_link = self.app_link
         self.session.cookies['sid'] = self.session_id
-        resp = self.session.get(app_link)
+        resp = self.session.get(self.app_link)
         assertion = self.get_saml_assertion(resp)
         return app_name, assertion
 


### PR DESCRIPTION
**TL;DR**: fix app_link handling when MFA is involved and prompting for app.


https://github.com/jmhale/okta-awscli/pull/54 changed the app-link handling so that the app-link profile config would be updated when prompting user for the app (i.e. when the profile did not specify app-link).

PR54 did not save the selected app-link into self.app_link though, which meant that if MFA was being used (which uses self.app_link) that it would fail with a stacktrace:

> Authenticating with Okta...
> Enter username: James.Bowe
> Enter password:
> Available apps:
> 1: Amazon Web Services
> 2: Non-Prod Workload Account Auth Landing
> 3: Prod Workload Account Auth Landing [MFA]
> Please select AWS app: 3
> Multi-factor Authentication required.
> Pick a factor:
> [ 0 ] Okta Verify App: SmartPhone_Android: A5_Pro
> [ 1 ] sms: +61 XXX XX0 370
> Selection: 0
> Traceback (most recent call last):
>  File “/usr/bin/okta-awscli”, line 11, in <module>
>    load_entry_point(‘okta-awscli==0.4.0’, ‘console_scripts’, ‘okta-awscli’)()
>  File “/usr/lib/python3.6/site-packages/click/core.py”, line 764, in __call__
>    return self.main(*args, **kwargs)
>  File “/usr/lib/python3.6/site-packages/click/core.py”, line 717, in main
>    rv = self.invoke(ctx)
>  File “/usr/lib/python3.6/site-packages/click/core.py”, line 956, in invoke
>    return ctx.invoke(self.callback, **ctx.params)
>  File “/usr/lib/python3.6/site-packages/click/core.py”, line 555, in invoke
>    return callback(*args, **kwargs)
>  File “/usr/lib/python3.6/site-packages/oktaawscli/okta_awscli.py”, line 113, in main
>    aws_auth, okta_profile, profile, verbose, logger, token, cache
>  File “/usr/lib/python3.6/site-packages/oktaawscli/okta_awscli.py”, line 19, in get_credentials
>    _, assertion = okta.get_assertion()
>  File “/usr/lib/python3.6/site-packages/oktaawscli/okta_auth.py”, line 363, in get_assertion
>    assertion = self.get_saml_assertion(resp)
>  File “/usr/lib/python3.6/site-packages/oktaawscli/okta_auth.py”, line 282, in get_saml_assertion
>    assertion = self.get_simple_assertion(html) or self.get_mfa_assertion(html)
>  File “/usr/lib/python3.6/site-packages/oktaawscli/okta_auth.py”, line 276, in get_mfa_assertion
>    resp = self.session.get(self.app_link)
>  File “/usr/lib/python3.6/site-packages/requests/sessions.py”, line 546, in get
>    return self.request(‘GET’, url, **kwargs)
>  File “/usr/lib/python3.6/site-packages/requests/sessions.py”, line 519, in request
>    prep = self.prepare_request(req)
>  File “/usr/lib/python3.6/site-packages/requests/sessions.py”, line 462, in prepare_request
>    hooks=merge_hooks(request.hooks, self.hooks),
>  File “/usr/lib/python3.6/site-packages/requests/models.py”, line 313, in prepare
>    self.prepare_url(url, params)
>  File “/usr/lib/python3.6/site-packages/requests/models.py”, line 387, in prepare_url
>    raise MissingSchema(error)
> requests.exceptions.MissingSchema: Invalid URL ‘None’: No schema supplied. Perhaps you meant http://None?
> make: *** [auth] Error 1

This change makes sure we update self.app_link so that get_mfa_assertion doesnt fail in this way.