### PR TITLE
Add support for choosing aws profile via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0] 2020-02-26
+### Added:
+- Allow `profile` to be set from config file in addition to command-line option.
+  - Thanks to: [@jrisebor](https://github.com/jrisebor)
+
 ## [0.4.1] 2020-02-25
 ### Added:
 - Pipenv support

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Parsing the HTML is still required to get the SAML assertion, after authenticati
 base-url = <your_okta_org>.okta.com
 
 ## The remaining parameters are optional.
-## You will be prompted for them, if they're not included here.
+## You may be prompted for them, if they're not included here.
 username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor   = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role     = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
+profile  = <aws_profile_to_store_credentials> # Sets your temporary credentials to a profile in `.aws/credentials`. Overridden by `--profile` command line flag
 app-link = <app_link_from_okta> # Found in Okta's configuration for your AWS account.
 duration = 3600 # duration in seconds to request a session token for, make sure your accounts (both AWS itself and the associated okta application) allow for large durations. default: 3600
 ```
@@ -55,7 +56,7 @@ duration = 3600 # duration in seconds to request a session token for, make sure 
 If no awscli commands are provided, then okta-awscli will simply output STS credentials to your credentials file, or console, depending on how `--profile` is set.
 
 Optional flags:
-- `--profile` Sets your temporary credentials to a profile in `.aws/credentials`. If omitted, credentials will output to console.
+- `--profile` Sets your temporary credentials to a profile in `.aws/credentials`. If omitted and not configured in `~/.okta-aws`, credentials will output to console.
 - `--force` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
 - `--verbose` More verbose output.
 - `--debug` Very verbose output. Useful for debugging.

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -29,6 +29,10 @@ class AwsAuth():
             self.role = parser.get(okta_profile, 'role')
             self.logger.debug("Setting AWS role to %s" % self.role)
 
+        if parser.has_option(okta_profile, 'profile') and not profile:
+            self.profile = parser.get(okta_profile, 'profile')
+            self.logger.debug("Setting AWS profile to %s" % self.profile)
+
 
     def choose_aws_role(self, assertion):
         """ Choose AWS role from SAML assertion """
@@ -80,10 +84,10 @@ of roles assigned to you.""" % self.role)
         credentials = response['Credentials']
         return credentials
 
-    def check_sts_token(self, profile):
+    def check_sts_token(self):
         """ Verifies that STS credentials are valid """
         # Don't check for creds if profile is blank
-        if not profile:
+        if not self.profile:
             return False
 
         parser = RawConfigParser()
@@ -97,11 +101,11 @@ of roles assigned to you.""" % self.role)
             self.logger.info("AWS credentials file does not exist. Not checking.")
             return False
 
-        elif not parser.has_section(profile):
+        elif not parser.has_section(self.profile):
             self.logger.info("No existing credentials found. Requesting new credentials.")
             return False
 
-        session = boto3.Session(profile_name=profile)
+        session = boto3.Session(profile_name=self.profile)
         sts = session.client('sts')
         try:
             sts.get_caller_identity()
@@ -114,7 +118,7 @@ of roles assigned to you.""" % self.role)
         self.logger.info("STS credentials are valid. Nothing to do.")
         return True
 
-    def write_sts_token(self, profile, access_key_id, secret_access_key, session_token):
+    def write_sts_token(self, access_key_id, secret_access_key, session_token):
         """ Writes STS auth information to credentials file """
         if not os.path.exists(self.creds_dir):
             os.makedirs(self.creds_dir)
@@ -123,17 +127,17 @@ of roles assigned to you.""" % self.role)
         if os.path.isfile(self.creds_file):
             config.read(self.creds_file)
 
-        if not config.has_section(profile):
-            config.add_section(profile)
+        if not config.has_section(self.profile):
+            config.add_section(self.profile)
 
-        config.set(profile, 'aws_access_key_id', access_key_id)
-        config.set(profile, 'aws_secret_access_key', secret_access_key)
-        config.set(profile, 'aws_session_token', session_token)
+        config.set(self.profile, 'aws_access_key_id', access_key_id)
+        config.set(self.profile, 'aws_secret_access_key', secret_access_key)
+        config.set(self.profile, 'aws_session_token', session_token)
 
         with open(self.creds_file, 'w+') as configfile:
             config.write(configfile)
-        self.logger.info("Temporary credentials written to profile: %s" % profile)
-        self.logger.info("Invoke using: aws --profile %s <service> <command>" % profile)
+        self.logger.info("Temporary credentials written to profile: %s" % self.profile)
+        self.logger.info("Invoke using: aws --profile %s <service> <command>" % self.profile)
 
     @staticmethod
     def __extract_available_roles_from(assertion):

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -98,7 +98,7 @@ of roles assigned to you.""" % self.role)
         credentials = response['Credentials']
         return credentials
 
-    def check_sts_token(self):
+    def check_sts_token(self, profile):
         """ Verifies that STS credentials are valid """
         # Don't check for creds if profile is blank
         if not self.profile:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -9,7 +9,7 @@ from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
-def get_credentials(aws_auth, okta_profile, profile,
+def get_credentials(aws_auth, okta_profile,
                     verbose, logger, totp_token, cache):
     """ Gets credentials from Okta """
 
@@ -35,7 +35,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     session_token = sts_token['SessionToken']
     session_token_expiry = sts_token['Expiration']
     logger.info("Session token expires on: %s" % session_token_expiry)
-    if not profile:
+    if not aws_auth.profile:
         exports = console_output(access_key_id, secret_access_key,
                                  session_token, verbose)
         if cache:
@@ -45,7 +45,7 @@ def get_credentials(aws_auth, okta_profile, profile,
             cache.close()
         exit(0)
     else:
-        aws_auth.write_sts_token(profile, access_key_id,
+        aws_auth.write_sts_token(access_key_id,
                                  secret_access_key, session_token)
 
 
@@ -102,15 +102,15 @@ def main(okta_profile, profile, verbose, version,
     if not okta_profile:
         okta_profile = "default"
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger)
-    if not aws_auth.check_sts_token(profile) or force:
-        if force and profile:
+    if not aws_auth.check_sts_token() or force:
+        if force and aws_auth.profile:
             logger.info("Force option selected, \
                 getting new credentials anyway.")
         elif force:
             logger.info("Force option selected, but no profile provided. \
                 Option has no effect.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache
+            aws_auth, okta_profile, verbose, logger, token, cache
         )
 
     if awscli_args:


### PR DESCRIPTION
Some of my coworkers have asked for this feature. Seems pretty handy to configure an `~/.aws/credentials` profile for each profile in `~/.okta-aws`.