### PR TITLE
Fix issues with empty or wrong credential files, sort roles

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -140,12 +140,16 @@ of roles assigned to you.""" % self.role)
         aws_attribute_role = 'https://aws.amazon.com/SAML/Attributes/Role'
         attribute_value_urn = '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'
         roles = []
+        temp_roles={}
         role_tuple = namedtuple("RoleTuple", ["principal_arn", "role_arn"])
         root = ET.fromstring(base64.b64decode(assertion))
         for saml2attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
             if saml2attribute.get('Name') == aws_attribute_role:
                 for saml2attributevalue in saml2attribute.iter(attribute_value_urn):
-                    roles.append(role_tuple(*saml2attributevalue.text.split(',')))
+                    tmp = saml2attributevalue.text.split(',')
+                    temp_roles[tmp[1]] = tmp[0]
+        for key in sorted(temp_roles.keys()):
+            roles.append(role_tuple(temp_roles[key],key))
         return roles
 
     @staticmethod

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -87,7 +87,6 @@ of roles assigned to you.""" % self.role)
             return False
 
         parser = RawConfigParser()
-        parser.read(self.creds_file)
 
         if not os.path.exists(self.creds_dir):
             self.logger.info("AWS credentials path does not exist. Not checking.")
@@ -97,8 +96,17 @@ of roles assigned to you.""" % self.role)
             self.logger.info("AWS credentials file does not exist. Not checking.")
             return False
 
-        elif not parser.has_section(profile):
+        parser.read(self.creds_file)
+        if not parser.has_section(profile):
             self.logger.info("No existing credentials found. Requesting new credentials.")
+            return False
+
+        # check if creds are normal
+        elif not parser.has_option(self.profile,'aws_access_key_id'):
+            self.logger.info("No AWS_ACCESS_KEY_ID. Requesting new credentials.")
+            return False
+        elif not parser.has_option(self.profile,'aws_secret_access_key'):
+            self.logger.info("No AWS_SECRET_ACCESS_KEY. Requesting new credentials.")
             return False
 
         session = boto3.Session(profile_name=profile)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -20,7 +20,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     role = aws_auth.choose_aws_role(assertion)
     principal_arn, role_arn = role
 
-    # disable saving role_qrn to config file
+    # disable saving role_arn to config file to avoid skipping role choice
     #okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
     duration = okta_auth_config.duration_for(okta_profile)
 

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -20,7 +20,8 @@ def get_credentials(aws_auth, okta_profile, profile,
     role = aws_auth.choose_aws_role(assertion)
     principal_arn, role_arn = role
 
-    okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
+    # disable saving role_qrn to config file
+    #okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
     duration = okta_auth_config.duration_for(okta_profile)
 
     sts_token = aws_auth.get_sts_token(
@@ -98,7 +99,8 @@ def main(okta_profile, profile, verbose, version,
     if debug:
         handler.setLevel(logging.DEBUG)
     logger.addHandler(handler)
-
+    if not profile:
+        profile = "default"
     if not okta_profile:
         okta_profile = "default"
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger)


### PR DESCRIPTION
Here're 3 changes:
1. Avoid saving role into config file. It's not handy when you have much roles accessible and you need to switch between them with AWS profiles
2. Sort role list output. Makes it easier to find necessary role in a big list.
3. Fix exceptions those are happening when you have empty or malformed section in `~/.aws/credentials`