### PR TITLE
Redirect prompt to `sys.stderr`

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup as bs
 
+from oktaawscli.util import input
+
 try:
     from u2flib_host import u2f, exc
     from u2flib_host.constants import APDU_WRONG_DATA
@@ -18,10 +20,6 @@ try:
 except ImportError:
     U2F_ALLOWED = False
 
-try:
-    input = raw_input
-except NameError:
-    pass
 
 class OktaAuth():
     """ Handles auth to Okta and returns SAML assertion """

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -5,10 +5,7 @@ import os
 from configparser import RawConfigParser
 from getpass import getpass
 
-try:
-    input = raw_input
-except NameError:
-    pass
+from oktaawscli.util import input
 
 class OktaAuthConfig():
     """ Config helper class """

--- a/oktaawscli/util.py
+++ b/oktaawscli/util.py
@@ -1,0 +1,15 @@
+from __future__ import print_function
+import sys
+
+try:
+    _input = raw_input
+except NameError:
+    _input = input
+
+
+def input(prompt=None):
+    if not prompt:
+        return _input()
+
+    print(prompt.rstrip('\n'), end='', file=sys.stderr, flush=True)
+    return _input()


### PR DESCRIPTION
This PR fixes following error.

```
$ $(okta-awscli --okta-profile my-profile)
005617
zsh: command not found: Enter
$ $(pipenv run okta-awscli --okta-profile my-profile)
Enter MFA token: 872314
$ 
```

`getpass.getpass()` of standard library sends a prompt to `/dev/tty` or `sys.stderr`, 
but built-in `input()` sends a prompt into stdout and we cannot redirect it.

So, I defined `oktaawscli.util.input()` wrapping built-in `input()` to display a prompt on `sys.stderr`.