### PR TITLE
Refresh role with force parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.1] 2020-03-11
+## [0.4.2] 2020-03-11
 ### Added:
 - Refresh role with force parameter
  - Thanks to: [@saurabhjambhule](https://github.com/saurabhjambhule)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.1] 2020-03-11
+### Added:
+- Refresh role with force parameter
+ - Thanks to: [@saurabhjambhule](https://github.com/saurabhjambhule)
+
 ## [0.4.1] 2020-02-25
 ### Added:
 - Pipenv support

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -33,10 +33,8 @@ class AwsAuth():
     def choose_aws_role(self, assertion, refresh_role):
         """ Choose AWS role from SAML assertion """
 
-        print("called...")
         roles = self.__extract_available_roles_from(assertion)
         if self.role:
-            self.logger.info("Inside.....")
             predefined_role = self.__find_predefined_role_from(roles)
             if predefined_role and not refresh_role:
                 self.logger.info("Using predefined role: %s" % self.role)
@@ -47,7 +45,6 @@ class AwsAuth():
                 self.logger.info("""Predefined role, %s, not found in the list
 of roles assigned to you.""" % self.role)
 
-        print("outside...")
         self.logger.info("Please choose a role.")
         role_options = self.__create_options_from(roles)
         for option in role_options:

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -30,20 +30,25 @@ class AwsAuth():
             self.logger.debug("Setting AWS role to %s" % self.role)
 
 
-    def choose_aws_role(self, assertion):
+    def choose_aws_role(self, assertion, refresh_role):
         """ Choose AWS role from SAML assertion """
 
+        print("called...")
         roles = self.__extract_available_roles_from(assertion)
         if self.role:
+            self.logger.info("Inside.....")
             predefined_role = self.__find_predefined_role_from(roles)
-            if predefined_role:
+            if predefined_role and not refresh_role:
                 self.logger.info("Using predefined role: %s" % self.role)
                 return predefined_role
+            elif refresh_role:
+                self.logger.info("""Refreshing role""")
             else:
                 self.logger.info("""Predefined role, %s, not found in the list
 of roles assigned to you.""" % self.role)
-                self.logger.info("Please choose a role.")
 
+        print("outside...")
+        self.logger.info("Please choose a role.")
         role_options = self.__create_options_from(roles)
         for option in role_options:
             print(option)
@@ -70,7 +75,7 @@ of roles assigned to you.""" % self.role)
         except ClientError as ex:
             if logger:
                 logger.error(
-                    "Could not retrieve credentials: %s" % 
+                    "Could not retrieve credentials: %s" %
                     ex.response['Error']['Message']
                 )
                 exit(-1)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -10,14 +10,17 @@ from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, logger, totp_token, cache):
+                    verbose, logger, totp_token, cache, refresh_role):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
-    role = aws_auth.choose_aws_role(assertion)
+    print("calling...")
+    role = aws_auth.choose_aws_role(assertion, refresh_role)
+    print(role)
+    print("done...")
     principal_arn, role_arn = role
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
@@ -109,8 +112,9 @@ def main(okta_profile, profile, verbose, version,
         elif force:
             logger.info("Force option selected, but no profile provided. \
                 Option has no effect.")
+        refresh_role = True if force else False
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -17,10 +17,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
-    print("calling...")
     role = aws_auth.choose_aws_role(assertion, refresh_role)
-    print(role)
-    print("done...")
     principal_arn, role_arn = role
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.1'
+__version__ = '0.4.2'


### PR DESCRIPTION
This PR addresses https://github.com/jmhale/okta-awscli/issues/122 and https://github.com/jmhale/okta-awscli/issues/125 issues.

This is pretty handy for users having multiple roles assigned to them.
With `--force` parameter, it will now prompt role choice. So that the user need not to manually remove existing role from config file, in case he/she wants to switch role. 