### PR TITLE
Adding support for looking up ARNs into account alias names

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -165,11 +165,17 @@ of roles assigned to you.""" % self.role)
                                       aws_access_key_id = access_key_id,
                                       aws_secret_access_key = secret_access_key,
                                       aws_session_token = session_token)
-                alias = client.list_account_aliases()['AccountAliases'][0]
-                rolename = role.role_arn.split(':')[5]
-                options.append('{i}: {accname} - {rolename}'.format(i=index+1,
+                try:
+                    alias = client.list_account_aliases()['AccountAliases'][0]
+                    rolename = role.role_arn.split(':')[5]
+                    option = '{i}: {accname} - {rolename}'.format(i=index+1,
                                                                   accname = alias,
-                                                                  rolename = rolename))
+                                                                  rolename = rolename)
+                except Exception as e:
+                    option = '{i}: {rolearn}'.format(i=index+1,
+                                                     rolearn = role.role_arn)
+                    pass
+                options.append(option)
             else:
                 options.append("%d: %s" % (index + 1, role.role_arn))
         return options

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -8,14 +8,14 @@ from configparser import RawConfigParser
 import boto3
 from botocore.exceptions import ClientError
 
-
 class AwsAuth():
     """ Methods to support AWS authentication using STS """
 
-    def __init__(self, profile, okta_profile, verbose, logger):
+    def __init__(self, profile, okta_profile, lookup, verbose, logger):
         home_dir = os.path.expanduser('~')
         self.creds_dir = home_dir + "/.aws"
         self.creds_file = self.creds_dir + "/credentials"
+        self.lookup = lookup
         self.profile = profile
         self.verbose = verbose
         self.logger = logger
@@ -44,7 +44,7 @@ class AwsAuth():
 of roles assigned to you.""" % self.role)
                 self.logger.info("Please choose a role.")
 
-        role_options = self.__create_options_from(roles)
+        role_options = self.__create_options_from(roles, assertion, self.lookup)
         for option in role_options:
             print(option)
 
@@ -149,10 +149,25 @@ of roles assigned to you.""" % self.role)
         return roles
 
     @staticmethod
-    def __create_options_from(roles):
+    def __create_options_from(roles, assertion, lookup=False):
         options = []
         for index, role in enumerate(roles):
-            options.append("%d: %s" % (index + 1, role.role_arn))
+            if lookup:
+                creds = AwsAuth.get_sts_token(role.role_arn, role.principal_arn, assertion, duration=900)
+                access_key_id = creds['AccessKeyId']
+                secret_access_key = creds['SecretAccessKey']
+                session_token = creds['SessionToken']
+                client = boto3.client('iam',
+                                      aws_access_key_id = access_key_id,
+                                      aws_secret_access_key = secret_access_key,
+                                      aws_session_token = session_token)
+                alias = client.list_account_aliases()['AccountAliases'][0]
+                rolename = role.role_arn.split(':')[5]
+                options.append('{i}: {accname} - {rolename}'.format(i=index+1,
+                                                                  accname = alias,
+                                                                  rolename = rolename))
+            else:
+                options.append("%d: %s" % (index + 1, role.role_arn))
         return options
 
     def __find_predefined_role_from(self, roles):

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -157,7 +157,11 @@ of roles assigned to you.""" % self.role)
                 access_key_id = creds['AccessKeyId']
                 secret_access_key = creds['SecretAccessKey']
                 session_token = creds['SessionToken']
+                arn_region = role.principal_arn.split(':')[1]
+                iam_region = 'us-gov-west-1' if arn_region == 'aws-us-gov' else 'us-east-1'
+
                 client = boto3.client('iam',
+                                      region_name = iam_region,
                                       aws_access_key_id = access_key_id,
                                       aws_secret_access_key = secret_access_key,
                                       aws_session_token = session_token)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -79,9 +79,10 @@ created. If omitted, credentials will output to console.\n")
 @click.option('-c', '--cache', is_flag=True, help='Cache the default profile credentials \
 to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
+@click.option('-l', '--lookup', is_flag=True, help='Look up AWS account names')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
-         debug, force, cache, awscli_args, token):
+         debug, force, cache, lookup, awscli_args, token):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -101,7 +102,7 @@ def main(okta_profile, profile, verbose, version,
 
     if not okta_profile:
         okta_profile = "default"
-    aws_auth = AwsAuth(profile, okta_profile, verbose, logger)
+    aws_auth = AwsAuth(profile, okta_profile, lookup, verbose, logger)
     if not aws_auth.check_sts_token(profile) or force:
         if force and profile:
             logger.info("Force option selected, \


### PR DESCRIPTION
The change translates the ARNs into human readable account names (technically aliases). That way, the account id in the ARN doesn't have to be looked up or remembered when someone is having multiple AWS accounts.

