### PR TITLE
Add validation for app-link url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.5.1] 2020-05-07
+### Added:
+- Url Validation of `app-link` in config
+
 ## [0.4.1] 2020-02-25
 ### Added:
 - Pipenv support

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -4,6 +4,8 @@ import os
 
 from configparser import RawConfigParser
 from getpass import getpass
+import validators
+
 
 try:
     input = raw_input
@@ -42,6 +44,11 @@ class OktaAuthConfig():
             app_link = self._value.get(okta_profile, 'app-link')
         elif self._value.has_option('default', 'app-link'):
             app_link = self._value.get('default', 'app-link')
+
+        if not validators.url(app_link):
+            self.logger.error("The app-link provided: %s is an invalid url" % app_link)
+            exit(-1)
+
         self.logger.info("App Link set as: %s" % app_link)
         return app_link
 

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.1'
+__version__ = '0.5.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click==7.0
 bs4==0.0.1
 boto3==1.9.71
 ConfigParser==3.5.0
+validators==0.11.2

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'bs4',
         'boto3',
         'ConfigParser',
+        'validators',
         ],
     extras_require={
         'U2F': ['python-u2flib-host']


### PR DESCRIPTION
I had an issue today where I had an invalid url as `app-link`. The okta mfa request came through to my device normally and then failed with: `ERROR - No Extra Verification` and then a stack trace of:

```Traceback (most recent call last):
  File "/usr/local/bin/okta-awscli", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/oktaawscli/okta_awscli.py", line 113, in main
    aws_auth, okta_profile, profile, verbose, logger, token, cache
  File "/usr/local/lib/python3.7/site-packages/oktaawscli/okta_awscli.py", line 19, in get_credentials
    _, assertion = okta.get_assertion()
  File "/usr/local/lib/python3.7/site-packages/oktaawscli/okta_auth.py", line 362, in get_assertion
    assertion = self.get_saml_assertion(resp)
  File "/usr/local/lib/python3.7/site-packages/oktaawscli/okta_auth.py", line 285, in get_saml_assertion
    self.logger.error("SAML assertion not valid: " + assertion)
TypeError: can only concatenate str (not "NoneType") to str
```

This commit adds url validation to the `app-link` during the loading of the config so that there is at least a valid url being passed into the remainder of the system.

The output of this change results in:


```
okta-awscli -f --okta-profile dev --profile dev
Enter password:
ERROR - The app-link provided: https://test.okta-emea.com/home/amazon_aws/<some-numbers>/<some-more-numbers> f is an invalid url

```