### PR TITLE
Add support for reversed provider/role assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.2] 2020-07-10
+### Added:
+- Support provider/role returning in unexpected order in assertion.
+
 ## [0.4.1] 2020-02-25
 ### Added:
 - Pipenv support

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -145,7 +145,11 @@ of roles assigned to you.""" % self.role)
         for saml2attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
             if saml2attribute.get('Name') == aws_attribute_role:
                 for saml2attributevalue in saml2attribute.iter(attribute_value_urn):
-                    roles.append(role_tuple(*saml2attributevalue.text.split(',')))
+                    result_set = saml2attributevalue.text.split(',')
+                    if result_set[0].split(':')[5].startswith('role/'):
+                        roles.append(role_tuple(*reversed(result_set)))
+                    else:
+                        roles.append(role_tuple(*result_set))
         return roles
 
     @staticmethod

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.1'
+__version__ = '0.4.2'


### PR DESCRIPTION
Per [AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html), the assertion return order is `<role>,<principal>`, but the prior code assumes `<principal>,<role>`. I'm not sure how it worked for others, but I've added non-breaking support in case the assertion returned is `<role>,<principal>`.