### PR TITLE
Make `check_sts_token` generous in what it deems an error.

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -132,7 +132,13 @@ of roles assigned to you.""" % self.role)
         except ClientError as ex:
             if ex.response['Error']['Code'] == 'ExpiredToken':
                 self.logger.info("Temporary credentials have expired. Requesting new credentials.")
-                return False
+            elif ex.response['Error']['Code'] == 'InvalidClientTokenId':
+                self.logger.info("Credential is invalid. Requesting new credentials.")
+            else:
+                # See https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
+                self.logger.info("An unhandled error occurred. Requesting new credentials.")
+
+            return False
 
         self.logger.info("STS credentials are valid. Nothing to do.")
         return True


### PR DESCRIPTION
I am seeing odd cases here and there where the AWS API returns an `InvalidClientTokenId` error when a token is expired, rather than the expected `ExpiredToken`. That means users encounter a case where an expired token cannot be refreshed without manually killing the token in `~/.aws/credentials`. Example error object:

```
{
    'Error': {
        'Code': 'InvalidClientTokenId',
        'Message': 'The security token included in the request is invalid',
        'Type': 'Sender'
    },
    'ResponseMetadata': {
        'HTTPHeaders': {
            'content-length': '305',
            'content-type': 'text/xml',
            'date': 'Wed, 30 Sep 2020 14:29:53 GMT',
            'x-amzn-requestid': 'UUID'
        },
        'HTTPStatusCode': 403,
        'RequestId': 'UUID',
        'RetryAttempts': 0
    }
}
```

This PR considers all the [known error conditions](https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html) as meaning a token needs to be reissued. I have added a specific error message for the well-known (to me, anyway) case of an expired message returning `InvalidClientTokenId`.

For some people or use-cases, this change might be too generous in what it considers an error requiring a new token. If that is the case, it would be nice to at least handle `InvalidClientTokenId`.