### PR TITLE
New CLI flag to indicate when the AWS role should be refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.0] 2021-02-20
+### Added
+- Command-line argument for refreshing AWS roles. ([#150](https://github.com/jmhale/okta-awscli/issues/150))
+  - Thanks to: [@rrhodes](https://github.com/rrhodes)
+
 ## [0.4.6] 2020-11-01
 ### Fixed
 - Error when saving app-link to `.okta-aws` profile. ([#148](https://github.com/jmhale/okta-awscli/issues/148))

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Optional flags:
 - `--cache` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)
 - `--okta-profile` Use a Okta profile, other than `default` in `.okta-aws`. Useful for multiple Okta tenants.
 - `--token` or `-t` Pass in the TOTP token from your authenticator
+- `--refresh-role` or `-r` Refresh the AWS role to be assumed. Previously incorporated in `--force`.
 - `--lookup` or `-l` Lookup and return the AWS Account Alias for each role, instead of returning the raw ARN. 
   - Note that this will attempt to perform `iam:ListAccountAliases` on every account that you have access to via Okta. This is important for two reasons:
     - All of your roles must have this permission attached to it via an IAM policy.

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -82,14 +82,15 @@ credentials in ~/.aws/credentials. If profile doesn't exist, it will be \
 created. If omitted, credentials will output to console.\n")
 @click.option('-c', '--cache', is_flag=True, help='Cache the default profile credentials \
 to ~/.okta-credentials.cache\n')
+@click.option('-r', '--refresh-role', is_flag=True, help='Refreshes the AWS role to be assumed')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.option('-l', '--lookup', is_flag=True, help='Look up AWS account names')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
-         debug, force, cache, lookup, awscli_args, 
-         token, okta_username, okta_password):
+         debug, force, cache, lookup, awscli_args,
+         refresh_role, token, okta_username, okta_password):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -116,7 +117,6 @@ def main(okta_profile, profile, verbose, version,
 
             logger.info("Force option selected, \
                 getting new credentials anyway.")
-        refresh_role = True if force else False
         get_credentials(
             aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password
         )

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.6'
+__version__ = '0.5.0'


### PR DESCRIPTION
What?
=====
Introducing a new CLI flag to indicate whether or not the AWS role should be refreshed.

Why?
====
This logic was previously incorporated into `--force` in [PR 127](https://github.com/jmhale/okta-awscli/pull/127) but this has led to breaking changes reported in #150.

Testing
======
Tested locally on my machine. Force flag no longer prompts for AWS role (as expected). Addition of `-r` or `--refresh-role` does prompt me for the AWS role again.

----
## Closes #150  