### PR TITLE
Fix - Load AWS profile from config if not provided as CLI arg

### DIFF
--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -112,6 +112,7 @@ def main(okta_profile, profile, verbose, version,
         okta_profile = "default"
 
     aws_auth = AwsAuth(profile, okta_profile, lookup, verbose, logger)
+    profile = aws_auth.profile
     if not aws_auth.check_sts_token(profile) or force:
         if force and profile:
 


### PR DESCRIPTION
Proposed fix for #180, #155

`profile` comes from an optional command line argument `--profile` and could be `None`. `AwsAuth` is fine with `profile=None` being passed into the constructor in which case it falls back to the AWS profile from the configuration. However, that fallback within `AwsAuth` cannot change the value of `profile`, which are then incorrectly treated as the effective profile instead of a command line argument.

### Testing

For #180, with the patch, it recognizes the profile from the configuration, instead of throwing a stack trace.
```
$  okta-awscli --okta-profile <some-profile> -v --debug 
DEBUG - Setting AWS role to ...
DEBUG - Setting AWS partition to AwsPartition.AWS
DEBUG - Setting AWS profile to production-apps
DEBUG - Checking STS token against ARN partition: AwsPartition.AWS
INFO - STS credentials are valid. Nothing to do.
```

For #155, it rotates the credentials when it is no longer valid
```
$ okta-awscli --okta-profile <some-profile> -v --debug 
DEBUG - Setting AWS role to ...
DEBUG - Setting AWS partition to AwsPartition.AWS
DEBUG - Setting AWS profile to production-apps
DEBUG - Checking STS token against ARN partition: AwsPartition.AWS
INFO - Temporary credentials have expired. Requesting new credentials.
DEBUG - Setting MFA factor to OKTA
INFO - App Link set as: ...
```